### PR TITLE
add plugin for forbidden strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,13 @@ module.exports.plugins = [
   [require('remark-lint-file-extension'), 'md'],
   [require('remark-lint-first-heading-level'), 1],
   [require('remark-lint-heading-style'), 'atx'],
+  [
+    require('remark-lint-prohibited-strings'),
+    [
+      { no: 'v8', yes: 'V8' },
+      { no: 'Javascript', yes: 'JavaScript' }
+    ]
+  ],
   [require('remark-lint-strong-marker'), '*'],
   [require('remark-lint-table-cell-padding'), 'padded']
 ];

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "remark-lint-no-table-indentation": "^1.0.0",
     "remark-lint-no-tabs": "^1.0.0",
     "remark-lint-no-unused-definitions": "^1.0.0",
+    "remark-lint-prohibited-strings": "^1.0.0",
     "remark-lint-rule-style": "^1.0.0",
     "remark-lint-strong-marker": "^1.0.0",
     "remark-lint-table-cell-padding": "^1.0.0",


### PR DESCRIPTION
This will allow us to lint for `v8` (instead of `V8`) and `Javascript`
(instead of `JavaScript`), etc.

This change will require https://github.com/nodejs/node/pull/17163 in node itself. That PR corrects these issues in the node codebase itself.