### PR TITLE
add rule to disallow trailing spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports.plugins = [
   require('remark-lint-no-shortcut-reference-image'),
   require('remark-lint-no-table-indentation'),
   require('remark-lint-no-tabs'),
+  require('remark-lint-no-trailing-spaces'),
   require('remark-lint-no-unused-definitions'),
   require('remark-lint-rule-style'),
   require('remark-lint-table-pipes'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -356,6 +356,14 @@
         "vfile-location": "^2.0.1"
       }
     },
+    "remark-lint-no-trailing-spaces": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-trailing-spaces/-/remark-lint-no-trailing-spaces-2.0.0.tgz",
+      "integrity": "sha512-UVb0xAFO5lsa/kRNC/qHOz7GuF91TjW7hk+m8hUircj1Nh53BP9rH24DJ/NVPF1Ve+u5k+pfOTJPqJcvD0zgUw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.2"
+      }
+    },
     "remark-lint-no-unused-definitions": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remark-lint-no-unused-definitions/-/remark-lint-no-unused-definitions-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "remark-lint-no-shortcut-reference-image": "^1.0.0",
     "remark-lint-no-table-indentation": "^1.0.0",
     "remark-lint-no-tabs": "^1.0.0",
+    "remark-lint-no-trailing-spaces": "^2.0.0",
     "remark-lint-no-unused-definitions": "^1.0.0",
     "remark-lint-prohibited-strings": "^1.0.0",
     "remark-lint-rule-style": "^1.0.0",


### PR DESCRIPTION
This rule currently finds three errors Node.js core .md files and no
false positives.