### PR TITLE
replace caret with marker

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports.plugins = [
   ],
   require('remark-lint-maximum-line-length'),
   require('remark-lint-no-auto-link-without-protocol'),
-  require('remark-lint-no-blockquote-without-caret'),
+  require('remark-lint-no-blockquote-without-marker'),
   require('remark-lint-no-duplicate-definitions'),
   require('remark-lint-no-file-name-articles'),
   require('remark-lint-no-file-name-consecutive-dashes'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -225,6 +225,18 @@
       "resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-caret/-/remark-lint-no-blockquote-without-caret-2.0.0.tgz",
       "integrity": "sha512-MsH0ZLa9J6FBiPn4JZ/yGDlw/3jYnUeKxF5HE87c3Go27UUKvxAEGcrcEkMkn3n5J3N4mc+ZstQ7GJwuq3nTog=="
     },
+    "remark-lint-no-blockquote-without-marker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-marker/-/remark-lint-no-blockquote-without-marker-2.0.2.tgz",
+      "integrity": "sha512-jkfZ4hFiviZttEo7Ac7GZWFgMQ/bdVPfSluLeuf+qwL8sQvR4ClklKJ0Xbkk3cLRjvlGsc8U8uZR8qqH5MSLoA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1",
+        "vfile-location": "^2.0.1"
+      }
+    },
     "remark-lint-no-duplicate-definitions": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remark-lint-no-duplicate-definitions/-/remark-lint-no-duplicate-definitions-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "remark-lint-list-item-indent": "^1.0.3",
     "remark-lint-maximum-line-length": "^1.1.0",
     "remark-lint-no-auto-link-without-protocol": "^1.0.0",
-    "remark-lint-no-blockquote-without-caret": "^2.0.0",
+    "remark-lint-no-blockquote-without-marker": "^2.0.2",
     "remark-lint-no-duplicate-definitions": "^1.0.0",
     "remark-lint-no-file-name-articles": "^1.0.0",
     "remark-lint-no-file-name-consecutive-dashes": "^1.0.0",


### PR DESCRIPTION
> remark-lint-no-blockquote-without-caret
> Deprecated: use remark-lint-no-blockquote-without-marker instead
https://www.npmjs.com/package/remark-lint-no-blockquote-without-caret